### PR TITLE
[2021-04-11] Merge events into master.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,7 +10,7 @@ import { DashboardComponent } from "./components/dashboard/dashboard.component";
 const routes: Routes = [
   { path: 'rules', component: AnnouncementsComponent },
   { path: 'calendar', component: MainCalendarComponent },
-  { path: 'reservation', component: ReservationComponent },
+  { path: 'event', component: ReservationComponent },
   { path: 'reports', component: ReportsComponent },
   { path: 'dashboard', component: DashboardComponent },
   { path: '',   redirectTo: '/rules', pathMatch: 'full' }

--- a/src/app/components/general-workspace/general-workspace.component.html
+++ b/src/app/components/general-workspace/general-workspace.component.html
@@ -6,8 +6,8 @@
       <li [ngbNavItem]="2" routerLink="/calendar">
         <a ngbNavLink>Calendar</a>
       </li>
-      <li [ngbNavItem]="3" *ngIf="isLoggedIn" routerLink="/reservation">
-        <a ngbNavLink>Reservation</a>
+      <li [ngbNavItem]="3" routerLink="/event">
+        <a ngbNavLink>Event</a>
       </li>
       <li [ngbNavItem]="4" *ngIf="isAdmin" routerLink="/reports">
         <a ngbNavLink>Reports</a>

--- a/src/app/components/main-calendar/main-calendar.component.css
+++ b/src/app/components/main-calendar/main-calendar.component.css
@@ -2,9 +2,13 @@
   margin-top: 10px;
 }
 
-ngb-datepicker {
-  margin-left: 13rem;
+.reminder {
+  font-style: italic;
 }
+
+/* ngb-datepicker {
+  margin-left: 0em;
+} */
 
 /* Make the hyperlinks look like bootstrap link
  * even without the href atrribute */

--- a/src/app/components/main-calendar/main-calendar.component.html
+++ b/src/app/components/main-calendar/main-calendar.component.html
@@ -8,6 +8,13 @@
       <!-- Row 1, Column 1, Row 1-->
       <div class="container-fluid">
         <div class="row">
+          <div class="col-5">
+            <ul class="list-group-flush">
+              <li class="list-group-item"><small class="reminder">Please go to the Events tab if you want to log an event.</small></li>
+              <li class="list-group-item"><small class="reminder">Click a date on the calendar to display the events for that day.</small></li>
+              <li class="list-group-item"><small class="reminder">Click an event (if there are any) on the table to right of the calendar to display its details.</small></li>
+            </ul>
+          </div>
           <div class="col">
             <ngb-datepicker #picker [(ngModel)]="calendar" (dateSelect)="onDateSelection($event)" outsideDays="hidden"></ngb-datepicker>
           </div>

--- a/src/app/components/main-calendar/main-calendar.component.ts
+++ b/src/app/components/main-calendar/main-calendar.component.ts
@@ -120,7 +120,7 @@ export class MainCalendarComponent implements OnInit {
     //send a request to the navigation bar to change the active tab
     this.nav.setActiveTab(3);
     //call Angular's router to redirect the user to the reservation page
-    this.router.navigate(['/reservation']);
+    this.router.navigate(['/event']);
   }
 
   /**
@@ -135,7 +135,7 @@ export class MainCalendarComponent implements OnInit {
     //send a request to the navigation bar to change the active tab
     this.nav.setActiveTab(3);
     //call Angular's router to redirect the user to the reservation page
-    this.router.navigate(['/reservation']);
+    this.router.navigate(['/event']);
   }
 
   /**

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -2,7 +2,7 @@
   -- It contains the login form, the brand logo, brand name,
   -- app title and the options menu. -->
 <nav class="navbar navbar-light bg-light" *ngIf="!FATALERROR">
-  <span class="navbar-brand">ITLog</span>
+  <span class="navbar-brand">IT Log</span>
   <span class="navbar-text mr-auto">The Irresitible Technical Logs for FT's Domain System</span>
   <!-- Start of the login form -->
   <form *ngIf="!isLoggedIn" class="form-inline" [formGroup]="loginForm" (ngSubmit)="onSubmit()" novalidate>

--- a/src/app/components/reports/reports.component.html
+++ b/src/app/components/reports/reports.component.html
@@ -1,10 +1,10 @@
 <div class="container-fluid" *ngIf="isAdmin">
   <h3 class= "report-title">Search Events</h3>
-  <small class="help">Search events and generate reports. The report may be displayed on a table on be downloaded as a spreadsheet for offline viewing.<br>
+  <small class="help">Search events and generate reports. The report may be displayed on a table or be downloaded as a spreadsheet for offline viewing.<br>
     Note: The "Current System Version" will only be enabled if a specific system has been selected. Checking the field will in turn disable the date
     fields and will automatically use the date of the latest system version in the query.<br>
     <span class="note">Warning! Searching with blank values in all of the query form's fields would return all of the events in the database.
-      This could potentially result in lots of data being displayed in the table at once. A spreadsheet is recommended to if all of the events
+      This could potentially result in lots of data being displayed in the table at once. A spreadsheet is recommended if all of the events
       are needed to be viewed.
     </span>
   </small>

--- a/src/app/components/reservation/reservation.component.html
+++ b/src/app/components/reservation/reservation.component.html
@@ -31,14 +31,11 @@
           <option *ngFor="let zone of zones; let i = index" [value]="zones[i]">
             {{zones[i]}}
           </option>
-          <!-- <option>{{selectedSystem != '' ? selectedSystem.zone1Prefix : ''}}</option>
-          <option>{{selectedSystem != '' ? selectedSystem.zone2Prefix : ''}}</option>
-          <option>{{selectedSystem != '' ? selectedSystem.zone1Prefix + '-' + selectedSystem.zone2Prefix : ''}}</option> -->
         </select>
       </div>
       <div class="form-group col-3">
         <label for="type">Event Type</label>
-        <select class="custom-select" [ngClass]="{'is-valid': isInsert || isEdit}" id="type" name="type" formControlName="type">
+        <select class="custom-select" [ngClass]="{'is-valid': isInsert || isEdit}" (change)="onEventChange($event.target.value)" id="type" name="type" formControlName="type">
           <option *ngFor="let eventType of eventTypes; let i = index" [value]="eventTypes[i]">
             {{eventTypes[i]}}
           </option>
@@ -89,9 +86,11 @@
         <small id="compiledsourcesHelp" class="form-text text-muted">Please use comma and space to separate mutiple entries. e.g. LEC06A, FTC0630</small>
       </div>
       <div class="form-group col">
-        <label for="apiused">APIs Used</label>
-        <input type="text" class="form-control" id="apiused" name="apiused" aria-describedby="apiusedHelp" formControlName="apiUsed">
-        <small id="apiusedHelp" class="form-text text-muted">Please use comma and space to separate mutiple entries. e.g. OPAY, IPAY</small>
+        <label for="apiused">{{isUpgrade ? 'System Version' : isMaintenance ? 'Reason' : 'APIs Used'}}</label>
+        <input type="text" class="form-control" [ngClass]="{'is-valid': isMaintenance || isUpgrade}" id="apiused" name="apiused" aria-describedby="apiusedHelp" formControlName="apiUsed">
+        <small *ngIf="!isUpgrade && !isMaintenance" id="apiusedHelp" class="form-text text-muted">Please use comma and space to separate mutiple entries. e.g. OPAY, IPAY</small>
+        <small *ngIf="isMaintenance" id="apiusedHelp" class="form-text text-muted">Please state a reason why this event needs to be done.</small>
+        <small *ngIf="isUpgrade" id="apiusedHelp" class="form-text text-muted">Please supply the version release that the system is upgrading into.</small>
       </div>
     </div>
     <button type="submit" *ngIf="isInsert || isEdit" class="btn" [ngClass]="{'btn-outline-primary': eventForm.invalid, 'btn-primary': eventForm.valid}" [disabled]="eventForm.invalid">Submit</button>
@@ -124,7 +123,7 @@
 </div>
 <div id="outer" class="container" *ngIf="!isLoggedIn">
   <div id="inner">
-    <h3><span id="loading-text">Please log in to access the page.<br>
-      If you are not supposed to be in this page, please click <a href="/rules">here.</a></span></h3>
+    <h3><span id="loading-text">Please log in to input or edit an event.<br>
+      If you just want to check out the events, click <a routerLink="/calendar">here.</a></span></h3>
   </div>
 </div>

--- a/src/app/components/reservation/reservation.component.ts
+++ b/src/app/components/reservation/reservation.component.ts
@@ -27,6 +27,8 @@ export class ReservationComponent implements OnInit {
   isInsert: boolean; //flag to signify that form is in insert mode
   isEdit: boolean; //flag to signify that form is in edit mode
   isConfirm: boolean; //flag to signify that form is in confirm mode
+  isUpgrade: boolean; //flag to signify that a system maintenance is being inserted
+  isMaintenance: boolean;
   eventForm: FormGroup; //the event formgroup object
   eventTypes: any[]; //array to hold the options for the event types select element
   isLoggedIn: boolean; //flag to indicate if user is logged in
@@ -206,6 +208,19 @@ export class ReservationComponent implements OnInit {
     }
   }
 
+  private setSystemMaintenace(maintenanceType?: string) {
+    if (maintenanceType == EventTypes.MAINTENANCE) {
+      this.isMaintenance = true;
+      this.isUpgrade = false;
+    } else if (maintenanceType == EventTypes.SYS_UPGRADE) {
+      this.isMaintenance = false;
+      this.isUpgrade = true;
+    } else {
+      this.isMaintenance = false;
+      this.isUpgrade = false;
+    }
+  }
+
   /**
    *
    */
@@ -296,6 +311,27 @@ export class ReservationComponent implements OnInit {
     this.selectedSystem = this.systems.find(x => x.globalPrefix == $event);
     this.eventForm.controls['zone'].setValue('');
     this.zones = this.setZones();
+  }
+
+  private onEventChange($event: any) {
+    if ($event == EventTypes.MAINTENANCE
+        || $event == EventTypes.SYS_UPGRADE) {
+      this.eventForm.controls['jiraCase'].disable();
+      this.eventForm.controls['featureOn'].disable();
+      this.eventForm.controls['featureOff'].disable();
+      this.eventForm.controls['compiledSources'].disable();
+      $event == EventTypes.MAINTENANCE ? this.setSystemMaintenace(EventTypes.MAINTENANCE) : this.setSystemMaintenace(EventTypes.SYS_UPGRADE);
+      this.eventForm.controls['apiUsed'].setValidators(Validators.required);
+      this.eventForm.controls['apiUsed'].updateValueAndValidity();
+    } else {
+      this.eventForm.controls['jiraCase'].enable();
+      this.eventForm.controls['featureOn'].enable();
+      this.eventForm.controls['featureOff'].enable();
+      this.eventForm.controls['compiledSources'].enable();
+      this.setSystemMaintenace();
+      this.eventForm.controls['apiUsed'].clearValidators();
+      this.eventForm.controls['apiUsed'].updateValueAndValidity();
+    }
   }
 
   /**

--- a/src/app/model/constants/properties.ts
+++ b/src/app/model/constants/properties.ts
@@ -3,7 +3,7 @@ export class ConfigNames {
 }
 
 export class RestUrls {
-  private static REST_SERVER: string = 'http://mancswcbman0278:8080/api';
+  private static REST_SERVER: string = 'http://localhost:8080/api';
   public static REST_GET_CONFIG: string = RestUrls.REST_SERVER + '/config';
   public static REST_GET_RULES: string = RestUrls.REST_SERVER + '/rules';
   public static REST_LDAP_URL: string = RestUrls.REST_SERVER + '/login/';


### PR DESCRIPTION
## Changes
### Properties File

- Changed the REST server address to the generic `localhost`.

### General Workspace Component (Navigation Tabs)

- Renamed the Reservation tab into Event. The name reservation is weird because users are not reserving for a system, except in some specific scenarios. The users are logging the events that they used the system for. As such, the name Event would be more fitting that Reservation.
- Displayed the Event tab even if the user is not logged in.

### Calendar Component

- Added reminders and help to the left side of the calendar, moving the calendar farther to the right.
- Updated the routes used by the calendar tab when referring to the Event tab, previously the Reservation tab.

### Navbar Component

- Modified the app's name from `ITLog` to `IT Log` to emphasize that the app is about "Logs".

### Reports Component

- Fixed some typos found on the help text.

### Reservation Component (Events Tab)

- The tab name changed, the route changed but the component's name didn't. Yes that's the standard procedure.
- Modified the behavior of the event form. Some fields will now be disabled if the user selected either Maintenance or System Upgrade in the Event Type field. The APIs Used field now changes its label and help text depending on the event type selected. It now also becomes a required field if the event type is either Maintenance or System Upgrade.
- Added two new flags, the Upgrade flag and the Maintenance flag to signify if the user selected either the Maintenance or the System Upgrade option in the Event Type field. 

### Routing

- Changed the route to the Event tab (previously the Reservation tab) from `/reservation` to `/event` to be consistent with the tab name being changed.